### PR TITLE
Replace `normal` font-style with an empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 All notable changes to this theme will be documented in this file.
 
 ## [Unreleased]
+  ### Changed
+  - `normal` font-style is not supported. Replace it with an empty string.
+
 
 ## [0.6] - 2023-01-24
 Introduce a brand new colors and schema. Prepare to support semantic colors.
+
 
 ## [0.5] - 2022-06-09
   ### Added
@@ -14,6 +18,7 @@ Introduce a brand new colors and schema. Prepare to support semantic colors.
   - Separate deploy tasks between vscode and vsx marketplaces
   - Change color of `punctuation.definition.entity` (e.q: `&copy;`)
   - Better color theme for PHP 8 attributes
+
 
 ## [0.4] - 2022-05-17
   ### Added

--- a/oxford-blue-color-theme.json
+++ b/oxford-blue-color-theme.json
@@ -121,7 +121,7 @@
             ],
             "settings": {
                 "foreground": "#ffa65e",
-                "fontStyle": "normal"
+                "fontStyle": ""
             }
         },
         {
@@ -154,7 +154,7 @@
             ],
             "settings": {
                 "foreground": "#ffa65e",
-                "fontStyle": "normal"
+                "fontStyle": ""
             }
         },
         {

--- a/src/token/genericToken.ts
+++ b/src/token/genericToken.ts
@@ -46,7 +46,7 @@ export default function setGenericToken(token: TokenColor) {
 
   token.set("Keyword Operators", ["keyword.operator"], {
     foreground: tokenColorsDef.keywordOperator,
-    fontStyle: "normal",
+    fontStyle: "",
   });
 
   token.set(
@@ -75,7 +75,7 @@ export default function setGenericToken(token: TokenColor) {
     ],
     {
       foreground: tokenColorsDef.dataType,
-      fontStyle: "normal",
+      fontStyle: "",
     }
   );
 


### PR DESCRIPTION
`normal` font style is not supported. The correct value is an empty string. The empty string will remove the inherited setting.